### PR TITLE
Change transport buttons

### DIFF
--- a/src/pydaw/themes/default/default.pytheme
+++ b/src/pydaw/themes/default/default.pytheme
@@ -96,7 +96,11 @@ QCheckBox#button_power::indicator
 
 QRadioButton#play_button::indicator::checked,
 QRadioButton#rec_button::indicator::checked,
-QRadioButton#stop_button::indicator::checked,
+QRadioButton#stop_button::indicator::checked
+{
+    background: none;
+}
+
 QRadioButton#tool_select::indicator::checked,
 QRadioButton#tool_draw::indicator::checked,
 QRadioButton#tool_erase::indicator::checked,
@@ -109,7 +113,11 @@ QCheckBox#button_power::indicator::checked
 
 QRadioButton#play_button::indicator::unchecked,
 QRadioButton#rec_button::indicator::unchecked,
-QRadioButton#stop_button::indicator::unchecked,
+QRadioButton#stop_button::indicator::unchecked
+{
+    background: none;
+}
+
 QRadioButton#tool_select::indicator::unchecked,
 QRadioButton#tool_draw::indicator::unchecked,
 QRadioButton#tool_erase::indicator::unchecked,
@@ -224,9 +232,8 @@ QRadioButton#stop_button::indicator
 {
     outline: none;
     border: none;
-    width:48px;
-    height:48px;
-    border: 1px solid #dddddd;
+    width: 56px;
+    height: 42px;
 }
 
 QRadioButton#play_button::indicator
@@ -234,10 +241,19 @@ QRadioButton#play_button::indicator
     image: url($STYLE_FOLDER/play.svg);
 }
 
+QRadioButton#play_button::indicator::checked
+{
+    image: url($STYLE_FOLDER/play_checked.svg);
+}
 
 QRadioButton#stop_button::indicator
 {
     image: url($STYLE_FOLDER/stop.svg);
+}
+
+QRadioButton#stop_button::indicator::checked
+{
+    image: url($STYLE_FOLDER/stop_checked.svg);
 }
 
 QRadioButton#rec_button::indicator
@@ -245,6 +261,10 @@ QRadioButton#rec_button::indicator
     image: url($STYLE_FOLDER/rec.svg);
 }
 
+QRadioButton#rec_button::indicator::checked
+{
+    image: url($STYLE_FOLDER/rec_checked.svg);
+}
 
 QSpinBox, QDoubleSpinBox
 {

--- a/src/pydaw/themes/default/play.svg
+++ b/src/pydaw/themes/default/play.svg
@@ -1,3 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
-  <path d="M0 0v6l6-3-6-3z" transform="translate(1 1)" />
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#5C6369" offset="24.5097258%"></stop>
+            <stop stop-color="#4B5257" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="0" y="0" width="112" height="84" rx="4"></rect>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Play" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <g id="Rectangle-1">
+                <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+                <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+                <use stroke="none" fill="none" xlink:href="#path-2"></use>
+            </g>
+            <polygon id="Triangle-1" fill="#C5D4D9" filter="url(#filter-3)" sketch:type="MSShapeGroup" transform="translate(56.000000, 42.000000) rotate(-270.000000) translate(-56.000000, -42.000000) " points="56 27 71 57 41 57 "></polygon>
+            <path d="M7,2 L107,2" id="Line" stroke-opacity="0.497763813" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M2,5 L2,79" id="Line" stroke-opacity="0.497763813" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
 </svg>

--- a/src/pydaw/themes/default/play_checked.svg
+++ b/src/pydaw/themes/default/play_checked.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="24.5097258%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#4B5257" offset="0%"></stop>
+            <stop stop-color="#5C6369" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="0" y="0" width="112" height="84" rx="4"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Play-checked-2" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <g id="Rectangle-1">
+                <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+                <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+                <use stroke="none" fill="none" xlink:href="#path-2"></use>
+            </g>
+            <polygon id="Triangle-1" stroke-opacity="0.2" stroke="#000000" fill="#3C464C" sketch:type="MSShapeGroup" transform="translate(56.000000, 42.000000) rotate(-270.000000) translate(-56.000000, -42.000000) " points="56 27 71 57 41 57 "></polygon>
+            <path d="M2,2 L110,2" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M2,2 L2,82" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/src/pydaw/themes/default/rec.svg
+++ b/src/pydaw/themes/default/rec.svg
@@ -1,3 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
-  <path d="M3 0c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" transform="translate(1 1)" />
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#5C6369" offset="24.5097258%"></stop>
+            <stop stop-color="#4B5257" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="1" y="1" width="112" height="84" rx="4"></rect>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Rectangle-1">
+            <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+            <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+            <use stroke="none" fill="none" xlink:href="#path-2"></use>
+        </g>
+        <circle id="Oval-1" fill="#C5D4D9" filter="url(#filter-3)" sketch:type="MSShapeGroup" cx="59" cy="44" r="15"></circle>
+        <path d="M6,3 L108,3" id="Line" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        <path d="M3,6 L3,80" id="Line" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+    </g>
 </svg>

--- a/src/pydaw/themes/default/rec_checked.svg
+++ b/src/pydaw/themes/default/rec_checked.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="24.5097258%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#4B5257" offset="0%"></stop>
+            <stop stop-color="#5C6369" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="0" y="0" width="112" height="84" rx="4"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Rec-checked-2" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <g id="Rectangle-1">
+                <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+                <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+                <use stroke="none" fill="none" xlink:href="#path-2"></use>
+            </g>
+            <circle id="Oval-1" stroke-opacity="0.2" stroke="#000000" fill="#3C464C" sketch:type="MSShapeGroup" cx="56" cy="42" r="15"></circle>
+            <path d="M2,2 L110,2" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M2,2 L2,82" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/src/pydaw/themes/default/stop.svg
+++ b/src/pydaw/themes/default/stop.svg
@@ -1,3 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
-  <path d="M0 0v6h6v-6h-6z" transform="translate(1 1)" />
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#5C6369" offset="24.5097258%"></stop>
+            <stop stop-color="#4B5257" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="0" y="0" width="112" height="84" rx="4"></rect>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Stop" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <g id="Rectangle-1">
+                <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+                <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+                <use stroke="none" fill="none" xlink:href="#path-2"></use>
+            </g>
+            <rect id="Rectangle-3" fill="#C5D4D9" filter="url(#filter-3)" sketch:type="MSShapeGroup" x="41" y="27" width="30" height="30"></rect>
+            <path d="M7,2 L107,2" id="Line" stroke-opacity="0.497763813" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M2,5 L2,79" id="Line" stroke-opacity="0.497763813" stroke="#82878C" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
 </svg>

--- a/src/pydaw/themes/default/stop_checked.svg
+++ b/src/pydaw/themes/default/stop_checked.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="114px" height="86px" viewBox="0 0 114 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.1 (15681) - http://www.bohemiancoding.com/sketch -->
+    <title>rec</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="24.5097258%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#4B5257" offset="0%"></stop>
+            <stop stop-color="#5C6369" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-2" x="0" y="0" width="112" height="84" rx="4"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Stop-checked-2" sketch:type="MSLayerGroup" transform="translate(1.000000, 1.000000)">
+            <g id="Rectangle-1">
+                <use stroke="#212326" stroke-width="1" fill="url(#linearGradient-1)" fill-rule="evenodd" sketch:type="MSShapeGroup" xlink:href="#path-2"></use>
+                <use stroke="#292B2E" stroke-width="1" fill="none" xlink:href="#path-2"></use>
+                <use stroke="none" fill="none" xlink:href="#path-2"></use>
+            </g>
+            <rect id="Rectangle-3" stroke-opacity="0.2" stroke="#000000" fill="#3C464C" sketch:type="MSShapeGroup" x="41" y="27" width="30" height="30"></rect>
+            <path d="M2,2 L110,2" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M2,2 L2,82" id="Line" stroke-opacity="0.25" stroke="#000000" stroke-width="2" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This includes new transport buttons (play, stop and rec). They're in SVG format, but I discovered that Qt doesn't fully support all of the properties in SVG files, so maybe we can use PNG instead.

Screenshots:
<img width="1792" alt="screen shot 2015-11-09 at 00 07 44" src="https://cloud.githubusercontent.com/assets/2357833/11025140/59669bb6-8676-11e5-9055-414f3e6a9085.png">
<img width="1792" alt="screen shot 2015-11-09 at 00 07 50" src="https://cloud.githubusercontent.com/assets/2357833/11025143/5e4f9b96-8676-11e5-8376-772fcc5b8090.png">
<img width="1792" alt="screen shot 2015-11-09 at 00 07 54" src="https://cloud.githubusercontent.com/assets/2357833/11025142/5d5132e0-8676-11e5-8f6f-77518b92ba02.png">
